### PR TITLE
Ensure text_ids are loaded from pickle

### DIFF
--- a/riveter/riveter.py
+++ b/riveter/riveter.py
@@ -60,6 +60,7 @@ class Riveter:
 
     def __init__(self, filename=None):
         self.texts = None
+        self.text_ids = None
         self.verb_score_dict = None
         self.persona_score_dict = None
         self.persona_sd_dict = None


### PR DESCRIPTION
The variable text_ids was not loaded together with the pickle because it was not defined in __init__, causing e.g. get_documents_for_persona() to fail. This change should fix it.